### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/T5/mcp_client.py
+++ b/T5/mcp_client.py
@@ -32,15 +32,15 @@ To integrate MCP tools into the AG2 framework, install the required dependencies
 pip install -U ag2[openai,mcp]
 ```
 
-> **Note:** If you have been using `autogen` or `pyautogen`, all you need to do is upgrade it using:  
+> **Note:** If you have been using `autogen` or `ag2`, all you need to do is upgrade it using:  
 > ```bash
 > pip install -U autogen[openai,mcp]
 > ```
 > or  
 > ```bash
-> pip install -U pyautogen[openai,mcp]
+> pip install -U ag2[openai,mcp]
 > ```
-> as `pyautogen`, `autogen`, and `ag2` are aliases for the same PyPI package.  
+> as `ag2`, `autogen`, and `ag2` are aliases for the same PyPI package.  
 
 ## Imports
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
